### PR TITLE
fix #85

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "react-dom": "^0.14.0",
     "react-document-title": "^2.0.1",
     "react-lazy-load": "^2.0.1",
-    "react-router": "^1.0.0-rc1",
+    "react-router": "^1.0.0",
     "react-swipe": "^2.3.0",
     "react-tappable": "^0.6.0",
     "reflux": "^0.3.0",


### PR DESCRIPTION
> https://github.com/rackt/react-router/blob/master/CHANGES.md#navigating
> 
> https://github.com/rackt/history/commit/a9db75ac71b645dbd512407d7876799b
> 70cab11c

不用修复。

"history": "^1.13.1” 是没有问题的

另外 react-router 之后会大改，
从 `history.push`
到 `router.push`,
看样子可能是要避开对history的依赖。
所以现在修复也没有必要。
