### PR TITLE
fix #109 修复history错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "webpack -p",
+    "preinstall": "npm install history@1.13.1",
     "postinstall": "npm run build",
     "start": "webpack-dev-server",
     "test": "karma start",
@@ -71,7 +72,6 @@
     "webpack-merge": "^0.2.0"
   },
   "dependencies": {
-    "history": "^1.13.1",
     "jquery": "^2.1.4",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",


### PR DESCRIPTION
npm ERR! peerinvalid The package history@1.16.0 does not satisfy its
siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-router@1.0.2 wants history@1.13.x

采用preinstall提前固定history的版本号，防止自动安装成@1.16.x。
