### PR TITLE
依据微信的授权限制调整路由

### DIFF
--- a/app/components/UI/YPUIOrderCard.jsx
+++ b/app/components/UI/YPUIOrderCard.jsx
@@ -44,8 +44,7 @@ class YPUIOrderCard extends React.Component {
    * @param orderId
    */
   payOrder = (e, orderId) => {
-    console.log('[YPUIOrderCard-payOrder]', orderId);
-    this.history.pushState(null, `/center/u/order/${orderId}/submit`);
+    this.history.pushState(null, `/center/u/order/submit/${orderId}`);
   };
 
   /**

--- a/app/components/layout/center/user/order/OrderDetailLayout.jsx
+++ b/app/components/layout/center/user/order/OrderDetailLayout.jsx
@@ -50,7 +50,7 @@ class OrderDetailLayout extends React.Component{
   }
 
   pay = e => {
-    this.props.history.pushState(null, `center/u/order/${this.state.order.Id}/submit`);
+    this.props.history.pushState(null, `center/u/order/submit/${this.state.order.Id}`);
   };
 
   render() {

--- a/app/components/layout/center/user/order/OrderSubmitLayout.jsx
+++ b/app/components/layout/center/user/order/OrderSubmitLayout.jsx
@@ -41,7 +41,7 @@ class OrderSubmitLayout extends React.Component {
         channel: ['alipay_wap', 'wx_pub', 'upacp_wap'],//渠道数组,视情况而定
         charge_url: `${API.ORDER.pay}${getCookie('pingToken')}`, //token地址
         charge_param: {
-          'callback': `#/center/u/order/${self.state.order.Id}/submit/result`,
+          'callback': `#/center/u/order/submit/${self.state.order.Id}/result`,
           'orderId': self.state.order.Id
         }  //订单Id
       };

--- a/app/index.js
+++ b/app/index.js
@@ -113,13 +113,15 @@ function main(){
           {/*用户中心*/}
           <Route path="u">
             <IndexRoute component={UserCenterPage} />
-            <Route path="order" component={UserOrderTabLayout} />
-            <Route path="order/:id">
-              <IndexRoute  component={UserOrderDetailLayout}/>
-              <Route path="submit">
+            <Route path="order">
+              <IndexRoute component={UserOrderTabLayout} />
+              <Route path="submit/:id">
                 <IndexRoute component={UserOrderSubmitLayout}/>
                 <Route path="result" component={UserOrderSubmitResultLayout}/>
               </Route>
+            </Route>
+            <Route path="order/:id">
+              <IndexRoute  component={UserOrderDetailLayout}/>
               <Route path="refund" component={UserOrderRefundLayout}/>
             </Route>
           </Route>


### PR DESCRIPTION
微信设置授权地址时会计算#之后的部分，直到最后一个/符（如果这时候后面还有内容，则被认定为参数忽略掉），因此调整原有/:id/submit为su
bmit/:id，以适应这一规则